### PR TITLE
Handle transaction cascade user-order-orderdetail

### DIFF
--- a/backend/src/main/java/com/ecommerce/backend/orderdetail/OrderDetailController.java
+++ b/backend/src/main/java/com/ecommerce/backend/orderdetail/OrderDetailController.java
@@ -33,7 +33,7 @@ public class OrderDetailController {
         } else if (orderID != null && productID == null) {
             orderDetailDTOList = orderDetailService
                     .fetchAllOrderDetailsByOrderID(orderID);
-        } else if (orderID == null && productID != null) {
+        } else if (orderID == null) {
             orderDetailDTOList = orderDetailService
                     .fetchAllOrderDetailsByProductID(productID);
         } else {


### PR DESCRIPTION
Xử lý vấn đề còn tồn đọng ở PR #71 
![image](https://user-images.githubusercontent.com/66414511/236194096-a179f308-d478-45e4-9f1d-e5acfb0ac694.png)

Handle các trường hợp **xóa table parent dẫn tới xóa table child** giữa user -> order -> order detail:

- **Order**:
  - **DELETE**: Khi Order Status là **PENDING** hoặc **CONFIRMED** sẽ điều chỉnh **Quantity Product** tương ứng với các OrderDetail của Order đó (còn COMPLETED / CANCELLED thì sẽ chỉ xóa Order) -> Sau khi xóa Order thành công thì trong database sẽ CASCADE các OrderDetail của Order này.

  - **UPDATE**: Khi **Order Status** bất kỳ **không phải CANCELLED** mà update thành **CANCELLED** sẽ điều chỉnh quantity trong Product tương ứng với các OrderDetail của Order đó.

- **OrderDetail**:
  - **ADD**: Chỉ được **ADD** nếu như Order Status đang ở trạng thái **PENDING** -> điều chỉnh **Quantity Product** (các status còn lại sẽ response 500).

  - **UPDATE**: Tương tự **ADD**.

  - **DELETE**: Khi **Order Status của OrderDetail** này là **PENDING** hoặc **CONFIRMED** sẽ điều chỉnh **Quantity Product** (còn COMPLETED / CANCELLED thì sẽ chỉ xóa OrderDetail).

- **User**: Khi **DELETE USER** sẽ gọi hàm xóa mọi **Order** thuộc User này (với mỗi Order thì sẽ xóa mọi **OrderDetail** thuộc Order đó) -> Các quy tắc điều chỉnh **Quantity Product** đã nói ở trên

**Kết luận:** 
1. Các lệnh **DELETE** rất tốn chi phi, tài nguyên nên hạn chế sử dụng

2. Trên **Frontend** khi handle các **OrderStatus** PENDING | CONFIRMED | COMPLETED | CANCELLED thì nên cập nhật Status 1 chiều và tuần tự
  - **Ví dụ:** PENDING chỉ sẽ được UPDATE thành CONFIRMED hoặc CANCELLED

**Luồng đi của Status trong nghiệp vụ**: 
1. User tạo đơn hàng vs status ban đầu là PENDING, bên EMPLOYEE/ADMIN sẽ CONFIRMED.
2. Nếu Order chưa CONFIRMED thì User đc phép CANCELLED Order của mình, nếu đã CONFIRMED thì không được phép (có thể ẩn button hoặc chặn trong thao tác).
4. Sau khi giao hàng thành công Status sẽ là COMPLETED